### PR TITLE
Remove the superfluous trailing ":" in the Linux color string

### DIFF
--- a/lscolors.js
+++ b/lscolors.js
@@ -135,7 +135,9 @@ function translateColorToLinux(colorString) {
       } else if (color === "h") {
         linuxColorString += "47";   //grey background
       }
-      linuxColorString += ":";
+      if ((i + 1) < colorString.length) {
+        linuxColorString += ":";
+      }
     }
   }
 


### PR DESCRIPTION
There's a superfluous trailing ":" in the Linux `LS_COLORS` string. This PR removes it by checking where it is in the element list before appending the ":".